### PR TITLE
Update keymesh.py

### DIFF
--- a/keymesh.py
+++ b/keymesh.py
@@ -233,6 +233,7 @@ class KeymeshPanel(bpy.types.Panel):
 def register():
     bpy.utils.register_class(KeyframeMesh)
     bpy.utils.register_class(PurgeKeymeshData)
+    bpy.utils.register_class(InitializeHandler)
     bpy.utils.register_class(KeymeshPanel)
     bpy.app.handlers.load_post.append(km_frame_handler)
     bpy.app.handlers.frame_change_post.clear()

--- a/keymesh.py
+++ b/keymesh.py
@@ -243,6 +243,7 @@ def register():
 def unregister():
     bpy.utils.unregister_class(KeyframeMesh)
     bpy.utils.unregister_class(PurgeKeymeshData)
+    bpy.utils.unregister_class(InitializeHandler)
     bpy.utils.unregister_class(KeymeshPanel)
     bpy.app.handlers.load_post.remove(km_frame_handler)
     bpy.app.handlers.frame_change_post.clear()


### PR DESCRIPTION
First attempt at a pull request, think it worked :)

Notes:

Update: In transferring the code to github I discovered I missed putting **bpy.utils.register_class(InitializeHandler)** in **register()** and **bpy.utils.unregister_class(InitializeHandler** in **unregister()**. I did 2 commits to fix this and it looks like they're in this pull request but I'm not sure.

* Mesh update lagging key frames when using keyboard frame navigation: 
Fixed by changing all instances of **bpy.app.handlers.frame_change_pre**
to **bpy.app.handlers.frame_change_post**

* Automatically initialize the frame handler when loading Keymesh scenes 
Added persistent function **km_frame_handler**. Appended it to **bpy.app.handlers.load_post**, in the **register()** function. Won't load the frame handler if it's not a Keymesh scene

* Added a class/function, **InitializeHandler/initialize_handler**, with corresponding panel button that (re)initializes the frame handler.  Not really necessary after adding automatic initialization, but retained in case some other script or addon causes the handler to stop working

* If you create a Keymesh keyframe and immediately undo Blender crashes: 
Fixed by adding **bl_options = {'REGISTER', 'UNDO'}** to **KeyframeMesh**
 
* Panel bl_idname not using Blender's new **__PT__** syntax: Shows an error in the system console; but doesn't really cause any problems, though it may in the future.
Changed **bl_idname = "panel.keymesh_panel"** to  **bl_idname = "VIEW3D_PT_keymesh_panel"**